### PR TITLE
Removing provisioner tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```hcl
 module "cloudwatch-alarms" {
-    source = "github.com/pbs/terraform-aws-cloudwatch-alarms-module?ref=0.0.1"
+    source = "github.com/pbs/terraform-aws-cloudwatch-alarms-module?ref=x.y.z"
 }
 ```
 
@@ -24,7 +24,7 @@ Integrate this module like so:
 
 ```hcl
 module "cloudwatch-alarms" {
-  source = "github.com/pbs/terraform-aws-cloudwatch-alarms-module?ref=0.0.1"
+  source = "github.com/pbs/terraform-aws-cloudwatch-alarms-module?ref=x.y.z"
 
   namespace       = "AWS/Lambda"
   lambda_function = aws_lambda_function.lambda.id
@@ -43,7 +43,7 @@ module "cloudwatch-alarms" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.0.1`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -77,7 +77,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_metric_alarm.alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/data.tf
+++ b/data.tf
@@ -1,1 +1,0 @@
-data "aws_caller_identity" "current" {}

--- a/locals.tf
+++ b/locals.tf
@@ -53,7 +53,6 @@ locals {
       "${var.organization}:billing:product"     = var.product
       "${var.organization}:billing:environment" = var.environment
       creator                                   = local.creator
-      provisioner                               = data.aws_caller_identity.current.user_id
       repo                                      = var.repo
     }
   )


### PR DESCRIPTION
This tag doesn't help much, and causes issues with dependencies updating in weird orders.